### PR TITLE
feat: use the new API (POST `/getToken`) for tokenUrl. and improve token renew.

### DIFF
--- a/lib/controllers/rtc_event_handlers.dart
+++ b/lib/controllers/rtc_event_handlers.dart
@@ -215,13 +215,12 @@ Future<RtcEngineEventHandler> rtcEngineEventHandler(
 
     agoraEventHandlers.onUserOffline?.call(connection, remoteUid, reason);
   }, onTokenPrivilegeWillExpire: (connection, token) async {
-    await getToken(
-      tokenUrl: sessionController.value.connectionData!.tokenUrl,
-      channelName: sessionController.value.connectionData!.channelName,
-      uid: sessionController.value.connectionData!.uid,
-      sessionController: sessionController,
-    );
-    await sessionController.value.engine?.renewToken(token);
+    final newToken = await generateRtcToken(sessionController);
+    if (newToken == null) {
+      log("Failed to renew token", name: tag, level: Level.error.value);
+    } else {
+      await sessionController.value.engine?.renewToken(newToken);
+    }
 
     agoraEventHandlers.onTokenPrivilegeWillExpire?.call(connection, token);
   }, onRemoteVideoStateChanged: (connection, remoteUid, state, reason, elapsed) {

--- a/lib/controllers/rtc_token_handler.dart
+++ b/lib/controllers/rtc_token_handler.dart
@@ -6,22 +6,52 @@ import 'package:agora_uikit/controllers/session_controller.dart';
 import 'package:agora_uikit/src/enums.dart';
 import 'package:http/http.dart' as http;
 
-/// Function to get the RTC token from the server. Follow t
-Future<void> getToken({
-  String? tokenUrl,
-  String? channelName,
-  int? uid = 0,
-  required SessionController sessionController,
+/// Function to get the RTC token from the server. Follow the server implementation.
+Future<String> getRtcToken({
+  required String tokenUrl,
+  required String channelName,
+  required String uid,
+  String role = "publisher",
+  int expire = 3600,
 }) async {
-  final response = await http
-      .get(Uri.parse('$tokenUrl/rtc/$channelName/publisher/uid/$uid'));
+  final base = Uri.parse(tokenUrl);
+
+  final response = await http.post(
+    base.resolve("/getToken"),
+    body: {
+      "tokenType": "rtc",
+      "channel": channelName,
+      "role": role,
+      "uid": uid, // the server expects a string
+      "expire": expire, // optional: expiration time in seconds (default: 3600)
+    },
+  );
+
   if (response.statusCode == HttpStatus.ok) {
-    sessionController.value = sessionController.value
-        .copyWith(generatedToken: jsonDecode(response.body)['rtcToken']);
+    return jsonDecode(response.body)['token'];
   } else {
-    log("${response.reasonPhrase}",
-        level: Level.error.value, name: "AgoraVideoUIKit");
-    log("Failed to generate the token : ${response.statusCode}",
-        level: Level.error.value, name: "AgoraVideoUIKit");
+    log("${response.reasonPhrase}", level: Level.error.value, name: "AgoraVideoUIKit");
+    log("Failed to generate the token : ${response.statusCode}", level: Level.error.value, name: "AgoraVideoUIKit");
+    throw Exception("Failed to generate the token : ${response.statusCode}");
+  }
+}
+
+Future<String?> generateRtcToken(SessionController sessionController) async {
+  final tokenUrl = sessionController.value.connectionData!.tokenUrl;
+  if (tokenUrl == null) {
+    log("Token URL is null", level: Level.error.value, name: "AgoraVideoUIKit");
+    return null;
+  }
+  try {
+    final token = await getRtcToken(
+      tokenUrl: tokenUrl,
+      channelName: sessionController.value.connectionData!.channelName,
+      uid: sessionController.value.connectionData!.uid.toString(),
+    );
+    sessionController.value = sessionController.value.copyWith(generatedToken: token);
+    return token;
+  } catch (e, s) {
+    log(e.toString(), stackTrace: s, level: Level.error.value, name: "AgoraVideoUIKit");
+    return null;
   }
 }

--- a/lib/controllers/rtm_client_event_handler.dart
+++ b/lib/controllers/rtm_client_event_handler.dart
@@ -57,10 +57,13 @@ Future<void> rtmClientEventHandler({
   agoraRtmClient.onTokenExpired = () {
     agoraRtmClientEventHandler.onTokenExpired?.call();
 
-    getRtmToken(
-      tokenUrl: sessionController.value.connectionData!.tokenUrl,
-      sessionController: sessionController,
-    );
+    generateRtmToken(sessionController).then((token) {
+      if (token != null) {
+        agoraRtmClient.renewToken(token);
+      } else {
+        log('Failed to renew the rtm token', level: Level.error.value, name: tag);
+      }
+    });
   };
 
   agoraRtmClient.onPeersOnlineStatusChanged = (peersStatus) {

--- a/lib/controllers/rtm_token_handler.dart
+++ b/lib/controllers/rtm_token_handler.dart
@@ -6,19 +6,55 @@ import 'package:agora_uikit/controllers/session_controller.dart';
 import 'package:agora_uikit/src/enums.dart';
 import 'package:http/http.dart' as http;
 
-Future<void> getRtmToken({
-  String? tokenUrl,
-  required SessionController sessionController,
+Future<String> getRtmToken({
+  required String tokenUrl,
+  required String channelName,
+  required String uid,
+  int expire = 3600,
 }) async {
-  final String url = "$tokenUrl/rtm/${sessionController.value.generatedRtmId}";
-  final rtmResponse = await http.get(Uri.parse(url));
-  if (rtmResponse.statusCode == HttpStatus.ok) {
-    sessionController.value = sessionController.value.copyWith(
-      generatedRtmToken: jsonDecode(rtmResponse.body)['rtmToken'],
-    );
+  final base = Uri.parse(tokenUrl);
+
+  final response = await http.post(
+    base.resolve("/getToken"),
+    body: {
+      "tokenType": "rtm",
+      "channel": channelName,
+      "uid": uid, // the server expects a string
+      "expire": expire, // optional: expiration time in seconds (default: 3600)
+    },
+  );
+
+  if (response.statusCode == HttpStatus.ok) {
+    return jsonDecode(response.body)['token'];
   } else {
-    log("${rtmResponse.reasonPhrase}", level: Level.error.value);
-    log('Failed to generate the rtm token : ${rtmResponse.statusCode}',
-        level: Level.error.value);
+    log("${response.reasonPhrase}", level: Level.error.value, name: "AgoraVideoUIKit");
+    log("Failed to generate the token : ${response.statusCode}", level: Level.error.value, name: "AgoraVideoUIKit");
+    throw Exception("Failed to generate the token : ${response.statusCode}");
+  }
+}
+
+Future<String?> generateRtmToken(SessionController sessionController) async {
+  final tokenUrl = sessionController.value.connectionData!.tokenUrl;
+  if (tokenUrl == null) {
+    log("Token URL is null", level: Level.error.value, name: "AgoraVideoUIKit");
+    return null;
+  }
+  final rtcChannelName = sessionController.value.connectionData!.channelName;
+  final rtmChannelName = sessionController.value.connectionData!.rtmChannelName;
+
+  final rtcUid = sessionController.value.connectionData!.uid.toString();
+  final rtmUid = sessionController.value.connectionData!.rtmUid;
+
+  try {
+    final token = await getRtmToken(
+      tokenUrl: tokenUrl,
+      channelName: rtmChannelName ?? rtcChannelName,
+      uid: rtmUid ?? rtcUid,
+    );
+    sessionController.value = sessionController.value.copyWith(generatedRtmToken: token);
+    return token;
+  } catch (e, s) {
+    log(e.toString(), stackTrace: s, level: Level.error.value, name: "AgoraVideoUIKit");
+    return null;
   }
 }

--- a/lib/controllers/session_controller.dart
+++ b/lib/controllers/session_controller.dart
@@ -178,17 +178,10 @@ class SessionController extends ValueNotifier<AgoraSettings> {
     await value.engine?.enableAudioVolumeIndication(
         interval: 200, smooth: 3, reportVad: true);
     if (value.connectionData?.tokenUrl != null) {
-      await getToken(
-        tokenUrl: value.connectionData!.tokenUrl,
-        channelName: value.connectionData!.channelName,
-        uid: value.connectionData!.uid,
-        sessionController: this,
-      );
+      await generateRtcToken(this);
+
       if (value.connectionData!.rtmEnabled) {
-        await getRtmToken(
-          tokenUrl: value.connectionData!.tokenUrl,
-          sessionController: this,
-        );
+        await generateRtmToken(this);
       }
     }
 


### PR DESCRIPTION
## Release Notes

- Feature: Using the latest API `tokenUrl` parameter. Now it hits `POST /getToken`. Requires `agora-token-service` higher than or equal to: [v1.4.1](https://github.com/AgoraIO-Community/agora-token-service/releases/tag/v1.4.1). (both RTC & RTM)
- Fixed: Previously the SDK wasn't calling the renewToken method of the native side with the right parameter. (both RTC & RTM)

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] The GitHub Actions pass building and linting. Linter returns no warnings or errors.
- [ ] The QA checklist below has been completed

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Previously it was hitting the old [Deprecated API Endpoints](https://github.com/AgoraIO-Community/agora-token-service#deprecated-methods) for generating tokens via the optional `tokenUrl` parameter.

Issue Number: N/A

## What is the new behavior?
Currently it will be hitting the new [API Endpoint](https://github.com/AgoraIO-Community/agora-token-service#gettoken) which is `POST /getToken`

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

- Impact: 
Users who are using the old `agora-token-service` (older than [v1.4.1](https://github.com/AgoraIO-Community/agora-token-service/releases/tag/v1.4.1)) which doesn't have the `POST /getToken` endpoint and using the `tokenUrl` parameter for authentication purposes will be having a breaking feature.