### PR TITLE
Disable Active Speaker when overrided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.3.7
+- Fixes active speaker bug when user overrides with manual pin
+
 ## 1.3.6
 
 - Fixes error [[#151](https://github.com/AgoraIO-Community/VideoUIKit-Flutter/issues/151)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.3.7
 - Fixes active speaker bug when user overrides with manual pin
+- Updates permission_handler to v11.0.0
 
 ## 1.3.6
 

--- a/lib/controllers/session_controller.dart
+++ b/lib/controllers/session_controller.dart
@@ -273,6 +273,11 @@ class SessionController extends ValueNotifier<AgoraSettings> {
     }
   }
 
+  /// Function to disableActiveSpeaker
+  void setActiveSpeakerDisabled(bool activeSpeakerDisabled) {
+    value = value.copyWith(isActiveSpeakerDisabled: activeSpeakerDisabled);
+  }
+
   /// Function to swap [AgoraUser] in the floating layout.
   void swapUser({required int index}) {
     final AgoraUser newUser = value.users[index];

--- a/lib/models/agora_rtm_mute_request.dart
+++ b/lib/models/agora_rtm_mute_request.dart
@@ -99,7 +99,7 @@ class AgoraUIKit {
   String platform = platformStr();
 
   String framework = "flutter";
-  String version = "1.3.6";
+  String version = "1.3.7";
 
   AgoraUIKit.fromJson(Map<String, dynamic> json)
       : platform = json['platform'],

--- a/lib/src/layout/floating_layout.dart
+++ b/lib/src/layout/floating_layout.dart
@@ -174,6 +174,10 @@ class _FloatingLayoutState extends State<FloatingLayout> {
                                                         onTap: () {
                                                           widget.client
                                                               .sessionController
+                                                              .setActiveSpeakerDisabled(
+                                                                  false);
+                                                          widget.client
+                                                              .sessionController
                                                               .swapUser(
                                                                   index: index);
                                                         },
@@ -240,6 +244,10 @@ class _FloatingLayoutState extends State<FloatingLayout> {
                                                               onTap: () {
                                                                 widget.client
                                                                     .sessionController
+                                                                    .setActiveSpeakerDisabled(
+                                                                        true);
+                                                                widget.client
+                                                                    .sessionController
                                                                     .swapUser(
                                                                         index:
                                                                             index);
@@ -254,7 +262,7 @@ class _FloatingLayoutState extends State<FloatingLayout> {
                                                                 ),
                                                                 padding:
                                                                     const EdgeInsets
-                                                                            .all(
+                                                                        .all(
                                                                         3.0),
                                                                 child: Icon(
                                                                   Icons
@@ -355,6 +363,10 @@ class _FloatingLayoutState extends State<FloatingLayout> {
                                                               onTap: () {
                                                                 widget.client
                                                                     .sessionController
+                                                                    .setActiveSpeakerDisabled(
+                                                                        true);
+                                                                widget.client
+                                                                    .sessionController
                                                                     .swapUser(
                                                                         index:
                                                                             index);
@@ -369,7 +381,7 @@ class _FloatingLayoutState extends State<FloatingLayout> {
                                                                 ),
                                                                 padding:
                                                                     const EdgeInsets
-                                                                            .all(
+                                                                        .all(
                                                                         3.0),
                                                                 child: Icon(
                                                                   Icons

--- a/lib/src/layout/floating_layout.dart
+++ b/lib/src/layout/floating_layout.dart
@@ -262,7 +262,7 @@ class _FloatingLayoutState extends State<FloatingLayout> {
                                                                 ),
                                                                 padding:
                                                                     const EdgeInsets
-                                                                        .all(
+                                                                            .all(
                                                                         3.0),
                                                                 child: Icon(
                                                                   Icons
@@ -381,7 +381,7 @@ class _FloatingLayoutState extends State<FloatingLayout> {
                                                                 ),
                                                                 padding:
                                                                     const EdgeInsets
-                                                                        .all(
+                                                                            .all(
                                                                         3.0),
                                                                 child: Icon(
                                                                   Icons

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,8 +15,8 @@ dependencies:
   flutter:
     sdk: flutter
   http: ">=0.13.1 <2.0.0"
-  lints: ">=1.0.1 <2.1.0"
-  permission_handler: ^10.2.0
+  lints: ">=1.0.1 <2.1.2"
+  permission_handler: ^11.0.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: agora_uikit
 description: Flutter plugin to simply integrate Agora Video Calling or Live
   Video Streaming to your app with just a few lines of code.
-version: 1.3.6
+version: 1.3.7
 homepage: https://www.agora.io/en/
 repository: https://github.com/AgoraIO-Community/VideoUIKit-Flutter
 
@@ -14,7 +14,7 @@ dependencies:
   agora_rtm: ^1.5.5
   flutter:
     sdk: flutter
-  http: '>=0.13.1 <2.0.0'
+  http: ">=0.13.1 <2.0.0"
   lints: ">=1.0.1 <2.1.0"
   permission_handler: ^10.2.0
 


### PR DESCRIPTION
> Release Version: 1.3.7

## Release Notes

- Fixes active speaker bug when user overrides with manual pin


Please check the type of change your PR introduces:
- [x] Bugfix

## What is the current behavior?
When a user is pinned, activeSpeaker tries to override that pin causing an exception

Issue Number: N/A


## What is the new behavior?
When user manually pins someone, activeUser detection is disabled until that user is unpinned

## Does this introduce a breaking change?

- [x] No
