### PR TITLE
fix the type mismatch issue while compiling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.3.8
+- Update types from agora_rtc_engine 6.3.0
+
 ## 1.3.7
 - Fixes active speaker bug when user overrides with manual pin
 - Updates permission_handler to v11.0.0

--- a/lib/agora_uikit.dart
+++ b/lib/agora_uikit.dart
@@ -16,10 +16,10 @@ export 'package:agora_rtc_engine/agora_rtc_engine.dart'
         RemoteAudioState,
         RemoteAudioStateReason,
         LocalAudioStreamState,
-        LocalAudioStreamError,
+        LocalAudioStreamReason,
         AudioVolumeInfo,
         LocalVideoStreamState,
-        LocalVideoStreamError,
+        LocalVideoStreamReason,
         AreaCode,
         UserInfo,
         ConnectionStateType,
@@ -34,11 +34,10 @@ export 'package:agora_rtc_engine/agora_rtc_engine.dart'
         AudioMixingStateType,
         AudioMixingReasonType,
         RtmpStreamPublishState,
-        RtmpStreamPublishErrorType,
+        RtmpStreamPublishReason,
         InjectStreamStatus,
         ChannelMediaRelayState,
         ChannelMediaRelayError,
-        ChannelMediaRelayEvent,
         StreamPublishState,
         StreamSubscribeState,
         RtmpStreamingEvent,
@@ -63,16 +62,15 @@ export 'package:agora_rtm/agora_rtm.dart'
         RtmPeerOnlineState,
         RtmPeerSubscriptionOption,
         RtmRemoteInvitationState;
-
 export 'package:permission_handler/permission_handler.dart';
 
 export 'models/agora_channel_data.dart' show AgoraChannelData;
 export 'models/agora_connection_data.dart' show AgoraConnectionData;
 export 'models/agora_rtc_event_handlers.dart' show AgoraRtcEventHandlers;
-export 'models/agora_rtm_client_event_handler.dart'
-    show AgoraRtmClientEventHandler;
 export 'models/agora_rtm_channel_event_handler.dart'
     show AgoraRtmChannelEventHandler;
+export 'models/agora_rtm_client_event_handler.dart'
+    show AgoraRtmClientEventHandler;
 export 'src/agora_client.dart' show AgoraClient;
 export 'src/buttons/buttons.dart' show AgoraVideoButtons;
 export 'src/enums.dart';

--- a/lib/controllers/rtc_event_handlers.dart
+++ b/lib/controllers/rtc_event_handlers.dart
@@ -143,9 +143,11 @@ Future<RtcEngineEventHandler> rtcEngineEventHandler(
       (connection, remoteUid, streamId, code, missed, cached) {
     agoraEventHandlers.onStreamMessageError
         ?.call(connection, remoteUid, streamId, code, missed, cached);
-  }, onChannelMediaRelayEvent: (code) {
-    agoraEventHandlers.onChannelMediaRelayEvent?.call(code);
-  }, onChannelMediaRelayStateChanged: (state, code) {
+  }, 
+  // onChannelMediaRelayEvent: (code) {
+  //   agoraEventHandlers.onChannelMediaRelayEvent?.call(code);
+  // }, 
+  onChannelMediaRelayStateChanged: (state, code) {
     agoraEventHandlers.onChannelMediaRelayStateChanged?.call(state, code);
   }, onAudioPublishStateChanged:
       (channel, oldState, newState, elapseSinceLastState) {

--- a/lib/controllers/rtc_event_handlers.dart
+++ b/lib/controllers/rtc_event_handlers.dart
@@ -143,10 +143,7 @@ Future<RtcEngineEventHandler> rtcEngineEventHandler(
       (connection, remoteUid, streamId, code, missed, cached) {
     agoraEventHandlers.onStreamMessageError
         ?.call(connection, remoteUid, streamId, code, missed, cached);
-  }, 
-  // onChannelMediaRelayEvent: (code) {
-  //   agoraEventHandlers.onChannelMediaRelayEvent?.call(code);
-  // }, 
+  },  
   onChannelMediaRelayStateChanged: (state, code) {
     agoraEventHandlers.onChannelMediaRelayStateChanged?.call(state, code);
   }, onAudioPublishStateChanged:

--- a/lib/controllers/rtc_event_handlers.dart
+++ b/lib/controllers/rtc_event_handlers.dart
@@ -144,7 +144,7 @@ Future<RtcEngineEventHandler> rtcEngineEventHandler(
     agoraEventHandlers.onStreamMessageError
         ?.call(connection, remoteUid, streamId, code, missed, cached);
   }, onChannelMediaRelayEvent: (code) {
-    agoraEventHandlers.onChannelMediaRelayEvent1?.call(code);
+    agoraEventHandlers.onChannelMediaRelayEvent?.call(code);
   }, onChannelMediaRelayStateChanged: (state, code) {
     agoraEventHandlers.onChannelMediaRelayStateChanged?.call(state, code);
   }, onAudioPublishStateChanged:

--- a/lib/controllers/rtc_event_handlers.dart
+++ b/lib/controllers/rtc_event_handlers.dart
@@ -144,7 +144,7 @@ Future<RtcEngineEventHandler> rtcEngineEventHandler(
     agoraEventHandlers.onStreamMessageError
         ?.call(connection, remoteUid, streamId, code, missed, cached);
   }, onChannelMediaRelayEvent: (code) {
-    agoraEventHandlers.onChannelMediaRelayEvent?.call(code);
+    agoraEventHandlers.onChannelMediaRelayEvent1?.call(code);
   }, onChannelMediaRelayStateChanged: (state, code) {
     agoraEventHandlers.onChannelMediaRelayStateChanged?.call(state, code);
   }, onAudioPublishStateChanged:

--- a/lib/models/agora_rtc_event_handlers.dart
+++ b/lib/models/agora_rtc_event_handlers.dart
@@ -186,7 +186,7 @@ class AgoraRtcEventHandlers {
   /// * [state] The state of the local video, see LocalVideoStreamState .
   /// * [error] The detailed error information, see LocalVideoStreamError .
   final void Function(VideoSourceType source, LocalVideoStreamState state,
-      LocalVideoStreamError error)? onLocalVideoStateChanged;
+      LocalVideoStreamReason error)? onLocalVideoStateChanged;
 
   /// Occurs when the remote video stream state changes.
   /// This callback does not work properly when the number of users (in the communication profile) or hosts (in the live streaming channel) in a channel exceeds 17.
@@ -351,7 +351,7 @@ class AgoraRtcEventHandlers {
 
   /// @nodoc
   final void Function(
-          RhythmPlayerStateType state, RhythmPlayerErrorType errorCode)?
+          RhythmPlayerStateType state, RhythmPlayerReason errorCode)?
       onRhythmPlayerStateChanged;
 
   /// Occurs when the SDK cannot reconnect to Agora's edge server 10 seconds after its connection to the server is interrupted.
@@ -443,7 +443,7 @@ class AgoraRtcEventHandlers {
   /// * [state] The state of the local audio. See localaudiostreamstate .
   /// * [error] Local audio state error codes. See LocalAudioStreamError .
   final void Function(RtcConnection connection, LocalAudioStreamState state,
-      LocalAudioStreamError error)? onLocalAudioStateChanged;
+      LocalAudioStreamReason error)? onLocalAudioStateChanged;
 
   /// Occurs when the remote audio state changes.
   /// When the audio state of a remote user (in a voice/video call channel) or host (in a live streaming channel) changes, the SDK triggers this callback to report the current state of the remote audio stream.This callback does not work properly when the number of users (in the communication profile) or hosts (in the live streaming channel) in a channel exceeds 17.
@@ -518,7 +518,7 @@ class AgoraRtcEventHandlers {
   /// * [state] The current state of the media push. See RtmpStreamPublishState .
   /// * [errCode] The detailed error information for the media push. See RtmpStreamPublishErrorType .
   final void Function(String url, RtmpStreamPublishState state,
-      RtmpStreamPublishErrorType errCode)? onRtmpStreamingStateChanged;
+      RtmpStreamPublishReason errCode)? onRtmpStreamingStateChanged;
 
   /// Reports events during the media push.
   ///
@@ -551,7 +551,7 @@ class AgoraRtcEventHandlers {
   ///
   ///
   /// * [code] The event code of channel media relay. See ChannelMediaRelayEvent .
-  final void Function(ChannelMediaRelayEvent code)? onChannelMediaRelayEvent;
+  final void Function(dynamic code)? onChannelMediaRelayEvent;
 
   /// @nodoc
   final void Function(bool isFallbackOrRecover)?

--- a/lib/models/agora_rtc_event_handlers.dart
+++ b/lib/models/agora_rtc_event_handlers.dart
@@ -551,7 +551,7 @@ class AgoraRtcEventHandlers {
   ///
   ///
   /// * [code] The event code of channel media relay. See ChannelMediaRelayEvent .
-  final void Function(dynamic code)? onChannelMediaRelayEvent;
+  // final void Function(dynamic code)? onChannelMediaRelayEvent;
 
   /// @nodoc
   final void Function(bool isFallbackOrRecover)?
@@ -805,7 +805,7 @@ class AgoraRtcEventHandlers {
     this.onTranscodingUpdated,
     this.onAudioRoutingChanged,
     this.onChannelMediaRelayStateChanged,
-    this.onChannelMediaRelayEvent,
+    // this.onChannelMediaRelayEvent,
     this.onLocalPublishFallbackToAudioOnly,
     this.onRemoteSubscribeFallbackToAudioOnly,
     this.onRemoteAudioTransportStats,

--- a/lib/models/agora_rtc_event_handlers.dart
+++ b/lib/models/agora_rtc_event_handlers.dart
@@ -547,12 +547,6 @@ class AgoraRtcEventHandlers {
           ChannelMediaRelayState state, ChannelMediaRelayError code)?
       onChannelMediaRelayStateChanged;
 
-  /// Reports events during the media stream relay.
-  ///
-  ///
-  /// * [code] The event code of channel media relay. See ChannelMediaRelayEvent .
-  // final void Function(dynamic code)? onChannelMediaRelayEvent;
-
   /// @nodoc
   final void Function(bool isFallbackOrRecover)?
       onLocalPublishFallbackToAudioOnly;
@@ -805,7 +799,6 @@ class AgoraRtcEventHandlers {
     this.onTranscodingUpdated,
     this.onAudioRoutingChanged,
     this.onChannelMediaRelayStateChanged,
-    // this.onChannelMediaRelayEvent,
     this.onLocalPublishFallbackToAudioOnly,
     this.onRemoteSubscribeFallbackToAudioOnly,
     this.onRemoteAudioTransportStats,

--- a/lib/models/agora_rtc_event_handlers.dart
+++ b/lib/models/agora_rtc_event_handlers.dart
@@ -551,7 +551,7 @@ class AgoraRtcEventHandlers {
   ///
   ///
   /// * [code] The event code of channel media relay. See ChannelMediaRelayEvent .
-  final void Function(dynamic code)? onChannelMediaRelayEvent;
+  final void Function(dynamic code)? onChannelMediaRelayEvent1;
 
   /// @nodoc
   final void Function(bool isFallbackOrRecover)?
@@ -805,7 +805,7 @@ class AgoraRtcEventHandlers {
     this.onTranscodingUpdated,
     this.onAudioRoutingChanged,
     this.onChannelMediaRelayStateChanged,
-    this.onChannelMediaRelayEvent,
+    this.onChannelMediaRelayEvent1,
     this.onLocalPublishFallbackToAudioOnly,
     this.onRemoteSubscribeFallbackToAudioOnly,
     this.onRemoteAudioTransportStats,

--- a/lib/models/agora_rtc_event_handlers.dart
+++ b/lib/models/agora_rtc_event_handlers.dart
@@ -551,7 +551,7 @@ class AgoraRtcEventHandlers {
   ///
   ///
   /// * [code] The event code of channel media relay. See ChannelMediaRelayEvent .
-  final void Function(dynamic code)? onChannelMediaRelayEvent1;
+  final void Function(dynamic code)? onChannelMediaRelayEvent;
 
   /// @nodoc
   final void Function(bool isFallbackOrRecover)?
@@ -805,7 +805,7 @@ class AgoraRtcEventHandlers {
     this.onTranscodingUpdated,
     this.onAudioRoutingChanged,
     this.onChannelMediaRelayStateChanged,
-    this.onChannelMediaRelayEvent1,
+    this.onChannelMediaRelayEvent,
     this.onLocalPublishFallbackToAudioOnly,
     this.onRemoteSubscribeFallbackToAudioOnly,
     this.onRemoteAudioTransportStats,

--- a/lib/models/agora_rtm_mute_request.dart
+++ b/lib/models/agora_rtm_mute_request.dart
@@ -99,7 +99,7 @@ class AgoraUIKit {
   String platform = platformStr();
 
   String framework = "flutter";
-  String version = "1.3.7";
+  String version = "1.3.8";
 
   AgoraUIKit.fromJson(Map<String, dynamic> json)
       : platform = json['platform'],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: agora_uikit
 description: Flutter plugin to simply integrate Agora Video Calling or Live
   Video Streaming to your app with just a few lines of code.
-version: 1.3.7
+version: 1.3.8
 homepage: https://www.agora.io/en/
 repository: https://github.com/AgoraIO-Community/VideoUIKit-Flutter
 
@@ -10,7 +10,7 @@ environment:
   flutter: ">=2.2.0"
 
 dependencies:
-  agora_rtc_engine: ^6.2.2
+  agora_rtc_engine: ^6.3.0
   agora_rtm: ^1.5.5
   flutter:
     sdk: flutter


### PR DESCRIPTION
## Release Version:

1.3.8

## Release Notes

- Removed deprecated `onChannelMediaRelayEvent` callback from `RtcEngineEventHandler`.
- fix the type mismatch issue while compiling.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] The GitHub Actions pass building and linting. Linter returns no warnings or errors.
- [x] The QA checklist below has been completed

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?

The `onChannelMediaRelayEvent` callback was present in the `RtcEngineEventHandler` class.

## What is the new behavior?

Removed the `onChannelMediaRelayEvent` callback as it was deprecated and no longer used.

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

This introduces a breaking change as the `onChannelMediaRelayEvent` callback has been removed.

## QA Checklist

### VideoUIKit Update Checklist (Minor or Patch Release)

- [x] Using the latest version of Agora's Video SDK
- [x] Example apps are all functional
- [x] Core features are still working (both ways across platforms)
- [x] Camera + Mic muting works for local and remote users
- [x] Users are added and removed correctly when they join and leave the channel
- [x] Older versions of the library gracefully handle changes (Create issue if not)
- [x] Builtin buttons all work as expected
- [x] Any newly deprecated methods are flagged as such inline and in documentation

#### QA Notes

Tested across iOS and Android devices, no issues encountered.

## Other information

No additional information.
