### PR TITLE
Allow newer `flutter_lints` versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.3.9
+- Update to support newer lints
+
 ## 1.3.8
 - Update types from agora_rtc_engine 6.3.0
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -6,7 +6,7 @@ void main() {
 }
 
 class MyApp extends StatefulWidget {
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp({super.key});
 
   @override
   State<MyApp> createState() => _MyAppState();

--- a/lib/models/agora_rtm_mute_request.dart
+++ b/lib/models/agora_rtm_mute_request.dart
@@ -99,7 +99,7 @@ class AgoraUIKit {
   String platform = platformStr();
 
   String framework = "flutter";
-  String version = "1.3.8";
+  String version = "1.3.9";
 
   AgoraUIKit.fromJson(Map<String, dynamic> json)
       : platform = json['platform'],

--- a/lib/src/buttons/buttons.dart
+++ b/lib/src/buttons/buttons.dart
@@ -52,7 +52,7 @@ class AgoraVideoButtons extends StatefulWidget {
   final bool? cloudRecordingEnabled;
 
   const AgoraVideoButtons({
-    Key? key,
+    super.key,
     required this.client,
     this.enabledButtons,
     this.extraButtons,
@@ -69,7 +69,7 @@ class AgoraVideoButtons extends StatefulWidget {
     this.onDisconnect,
     this.addScreenSharing = false,
     this.cloudRecordingEnabled = false,
-  }) : super(key: key);
+  });
 
   @override
   State<AgoraVideoButtons> createState() => _AgoraVideoButtonsState();

--- a/lib/src/buttons/cloud_recording_button.dart
+++ b/lib/src/buttons/cloud_recording_button.dart
@@ -6,10 +6,10 @@ class CloudRecordingButton extends StatelessWidget {
   final Widget? child;
   final AgoraClient client;
   const CloudRecordingButton({
-    Key? key,
+    super.key,
     required this.client,
     this.child,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -26,8 +26,7 @@ class CloudRecordingButton extends StatelessWidget {
 
 class RecordingStateButton extends StatelessWidget {
   final AgoraClient client;
-  const RecordingStateButton({Key? key, required this.client})
-      : super(key: key);
+  const RecordingStateButton({super.key, required this.client});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/layout/floating_layout.dart
+++ b/lib/src/layout/floating_layout.dart
@@ -42,7 +42,7 @@ class FloatingLayout extends StatefulWidget {
   final bool? useAndroidSurfaceView;
 
   const FloatingLayout({
-    Key? key,
+    super.key,
     required this.client,
     this.floatingLayoutContainerHeight,
     this.floatingLayoutContainerWidth,
@@ -55,7 +55,7 @@ class FloatingLayout extends StatefulWidget {
     this.renderModeType = RenderModeType.renderModeHidden,
     this.useAndroidSurfaceView = false,
     this.useFlutterTexture = false,
-  }) : super(key: key);
+  });
 
   @override
   State<FloatingLayout> createState() => _FloatingLayoutState();
@@ -262,7 +262,7 @@ class _FloatingLayoutState extends State<FloatingLayout> {
                                                                 ),
                                                                 padding:
                                                                     const EdgeInsets
-                                                                            .all(
+                                                                        .all(
                                                                         3.0),
                                                                 child: Icon(
                                                                   Icons
@@ -381,7 +381,7 @@ class _FloatingLayoutState extends State<FloatingLayout> {
                                                                 ),
                                                                 padding:
                                                                     const EdgeInsets
-                                                                            .all(
+                                                                        .all(
                                                                         3.0),
                                                                 child: Icon(
                                                                   Icons

--- a/lib/src/layout/floating_layout.dart
+++ b/lib/src/layout/floating_layout.dart
@@ -262,7 +262,7 @@ class _FloatingLayoutState extends State<FloatingLayout> {
                                                                 ),
                                                                 padding:
                                                                     const EdgeInsets
-                                                                        .all(
+                                                                            .all(
                                                                         3.0),
                                                                 child: Icon(
                                                                   Icons
@@ -381,7 +381,7 @@ class _FloatingLayoutState extends State<FloatingLayout> {
                                                                 ),
                                                                 padding:
                                                                     const EdgeInsets
-                                                                        .all(
+                                                                            .all(
                                                                         3.0),
                                                                 child: Icon(
                                                                   Icons

--- a/lib/src/layout/grid_layout.dart
+++ b/lib/src/layout/grid_layout.dart
@@ -18,12 +18,12 @@ class GridLayout extends StatefulWidget {
   final RenderModeType renderModeType;
 
   const GridLayout({
-    Key? key,
+    super.key,
     required this.client,
     this.showNumberOfUsers,
     this.disabledVideoWidget = const DisabledVideoWidget(),
     this.renderModeType = RenderModeType.renderModeHidden,
-  }) : super(key: key);
+  });
 
   @override
   State<GridLayout> createState() => _GridLayoutState();
@@ -183,8 +183,7 @@ class _GridLayoutState extends State<GridLayout> {
 
 class DisabledVideoStfWidget extends StatefulWidget {
   final Widget? disabledVideoWidget;
-  const DisabledVideoStfWidget({Key? key, this.disabledVideoWidget})
-      : super(key: key);
+  const DisabledVideoStfWidget({super.key, this.disabledVideoWidget});
 
   @override
   State<DisabledVideoStfWidget> createState() => _DisabledVideoStfWidgetState();

--- a/lib/src/layout/layout.dart
+++ b/lib/src/layout/layout.dart
@@ -42,7 +42,7 @@ class AgoraVideoViewer extends StatefulWidget {
   final RenderModeType renderModeType;
 
   const AgoraVideoViewer({
-    Key? key,
+    super.key,
     required this.client,
     this.layoutType = Layout.grid,
     this.floatingLayoutContainerHeight,
@@ -54,7 +54,7 @@ class AgoraVideoViewer extends StatefulWidget {
     this.enableHostControls = false,
     this.showNumberOfUsers = false,
     this.renderModeType = RenderModeType.renderModeHidden,
-  }) : super(key: key);
+  });
 
   @override
   State<AgoraVideoViewer> createState() => _AgoraVideoViewerState();

--- a/lib/src/layout/one_to_one_layout.dart
+++ b/lib/src/layout/one_to_one_layout.dart
@@ -19,13 +19,13 @@ class OneToOneLayout extends StatefulWidget {
   final RenderModeType? renderModeType;
 
   const OneToOneLayout({
-    Key? key,
+    super.key,
     required this.client,
     this.disabledVideoWidget = const DisabledVideoWidget(),
     this.showAVState,
     this.enableHostControl,
     this.renderModeType = RenderModeType.renderModeHidden,
-  }) : super(key: key);
+  });
 
   @override
   State<OneToOneLayout> createState() => _OneToOneLayoutState();

--- a/lib/src/layout/widgets/disabled_video_widget.dart
+++ b/lib/src/layout/widgets/disabled_video_widget.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 
 /// Widget that is displayed when local/remote video is disabled.
 class DisabledVideoWidget extends StatefulWidget {
-  const DisabledVideoWidget({Key? key}) : super(key: key);
+  const DisabledVideoWidget({super.key});
 
   @override
   State<DisabledVideoWidget> createState() => _DisabledVideoWidgetState();

--- a/lib/src/layout/widgets/host_controls.dart
+++ b/lib/src/layout/widgets/host_controls.dart
@@ -9,12 +9,12 @@ class HostControls extends StatefulWidget {
   final int index;
 
   const HostControls({
-    Key? key,
+    super.key,
     required this.videoDisabled,
     required this.muted,
     required this.client,
     required this.index,
-  }) : super(key: key);
+  });
 
   @override
   State<HostControls> createState() => _HostControlsState();

--- a/lib/src/layout/widgets/number_of_users.dart
+++ b/lib/src/layout/widgets/number_of_users.dart
@@ -5,9 +5,9 @@ class NumberOfUsers extends StatefulWidget {
   final int userCount;
 
   const NumberOfUsers({
-    Key? key,
+    super.key,
     this.userCount = 0,
-  }) : super(key: key);
+  });
 
   @override
   State<NumberOfUsers> createState() => _NumberOfUsersState();

--- a/lib/src/layout/widgets/user_av_state_widget.dart
+++ b/lib/src/layout/widgets/user_av_state_widget.dart
@@ -7,10 +7,10 @@ class UserAVStateWidget extends StatefulWidget {
   final bool muted;
 
   const UserAVStateWidget({
-    Key? key,
+    super.key,
     required this.videoDisabled,
     required this.muted,
-  }) : super(key: key);
+  });
 
   @override
   State<UserAVStateWidget> createState() => _UserAVStateWidgetState();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   flutter:
     sdk: flutter
   http: ">=0.13.1 <2.0.0"
-  lints: ">=1.0.1 <2.1.2"
+  lints: ">=1.0.1"
   permission_handler: ^11.0.0
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: agora_uikit
 description: Flutter plugin to simply integrate Agora Video Calling or Live
   Video Streaming to your app with just a few lines of code.
-version: 1.3.8
+version: 1.3.9
 homepage: https://www.agora.io/en/
 repository: https://github.com/AgoraIO-Community/VideoUIKit-Flutter
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] The GitHub Actions pass building and linting. Linter returns no warnings or errors.
- [x] The QA checklist below has been completed

The only linter message that came up due to this change was [`use_super_parameters`](https://dart.dev/tools/linter-rules/use_super_parameters). I applied the "quick fix" for each message, so now there are no longer any issues.

<br>

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): **dependency change**

<br>

## Summary of changes

This change removes the version restriction for the `lints` dependency.

```yaml
# before
  lints: ">=1.0.1 <2.1.2"

# after
  lints: ">=1.0.1"
```

Once this change is implemented, developers who use this plugin won't be prevented from using new linting features.

<br>

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

The `lints` package is just for static analysis, so there shouldn't be any impact on functionality.