### PR TITLE
sharedNativeHandle exposed

### DIFF
--- a/lib/controllers/rtc_buttons.dart
+++ b/lib/controllers/rtc_buttons.dart
@@ -52,7 +52,7 @@ Future<void> endCall({required SessionController sessionController}) async {
   await sessionController.value.engine?.leaveChannel();
   if (sessionController.value.connectionData!.rtmEnabled) {
     await sessionController.value.agoraRtmChannel?.leave();
-    await sessionController.value.agoraRtmClient?.logout();
+    // await sessionController.value.agoraRtmClient?.logout();
   }
   await sessionController.value.engine?.release();
 }

--- a/lib/controllers/session_controller.dart
+++ b/lib/controllers/session_controller.dart
@@ -23,10 +23,12 @@ import 'package:http/http.dart' as http;
 import 'package:permission_handler/permission_handler.dart';
 
 class SessionController extends ValueNotifier<AgoraSettings> {
-  SessionController()
+  SessionController({Object? sharedNativeHandle})
       : super(
           AgoraSettings(
-            engine: createAgoraRtcEngine(),
+            engine: createAgoraRtcEngine(
+              sharedNativeHandle: sharedNativeHandle,
+            ),
             agoraRtmChannel: null,
             agoraRtmClient: null,
             users: [],

--- a/lib/controllers/session_controller.dart
+++ b/lib/controllers/session_controller.dart
@@ -203,6 +203,9 @@ class SessionController extends ValueNotifier<AgoraSettings> {
       options: ChannelMediaOptions(
         channelProfile: ChannelProfileType.channelProfileLiveBroadcasting,
         clientRoleType: ClientRoleType.clientRoleBroadcaster,
+        customVideoTrackId: value.connectionData!.customVideoTrackId,
+        publishCustomVideoTrack:
+            value.connectionData!.customVideoTrackId != null,
       ),
     );
   }

--- a/lib/models/agora_connection_data.dart
+++ b/lib/models/agora_connection_data.dart
@@ -42,6 +42,8 @@ class AgoraConnectionData {
 
   final Function? cloudRecordingCallback;
 
+  final int? customVideoTrackId;
+
   AgoraConnectionData({
     required this.appId,
     required this.channelName,
@@ -58,6 +60,7 @@ class AgoraConnectionData {
     this.screenSharingUid = 1000,
     this.screenSharingEnabled = true,
     this.cloudRecordingCallback,
+    this.customVideoTrackId,
   });
 
   AgoraConnectionData copyWith({
@@ -76,6 +79,7 @@ class AgoraConnectionData {
     int? screenSharingUid,
     bool? screenSharingEnabled,
     Function? cloudRecordingCallback,
+    int? customVideoTrackId,
   }) {
     return AgoraConnectionData(
       appId: appId ?? this.appId,
@@ -94,6 +98,7 @@ class AgoraConnectionData {
       screenSharingEnabled: screenSharingEnabled ?? this.screenSharingEnabled,
       cloudRecordingCallback:
           cloudRecordingCallback ?? this.cloudRecordingCallback,
+      customVideoTrackId: customVideoTrackId ?? this.customVideoTrackId,
     );
   }
 }

--- a/lib/src/agora_client.dart
+++ b/lib/src/agora_client.dart
@@ -34,6 +34,10 @@ class AgoraClient {
   /// [AgoraRtmChannelEventHandlers] is a class that contains all the Agora RTM channel event handlers. Use it to add your own functions or methods.
   final AgoraRtmChannelEventHandler? agoraRtmChannelEventHandler;
 
+  /// [sharedNativeHandle] is a shared native handle that can be used to share data between the UIKit and the native code.
+  /// Refer to https://github.com/AgoraIO-Extensions/Agora-Flutter-SDK/blob/main/example/lib/examples/advanced/process_video_raw_data/process_video_raw_data.dart
+  final Object? sharedNativeHandle;
+
   bool _initialized = false;
 
   AgoraClient({
@@ -43,7 +47,11 @@ class AgoraClient {
     this.agoraEventHandlers,
     this.agoraRtmClientEventHandler,
     this.agoraRtmChannelEventHandler,
-  }) : _initialized = false;
+    this.sharedNativeHandle,
+  })  : _initialized = false,
+        _sessionController = SessionController(
+          sharedNativeHandle: sharedNativeHandle,
+        );
 
   /// Useful to check if [AgoraClient] is ready for further usage
   bool get isInitialized => _initialized;
@@ -62,7 +70,8 @@ class AgoraClient {
   }
 
   // This is our "state" object that the UI Kit works with
-  final SessionController _sessionController = SessionController();
+  final SessionController _sessionController;
+
   SessionController get sessionController {
     return _sessionController;
   }


### PR DESCRIPTION
I needed this `sharedNativeHandle`to be able to [Interact with Agora RTC Native SDK](https://github.com/AgoraIO-Extensions/Agora-Flutter-SDK?tab=readme-ov-file#interact-with-agora-rtc-native-sdkandroidios-only). Thought that it may be useful for someone else as well.